### PR TITLE
V1.0 positive and negative shift working Fixes #11

### DIFF
--- a/cipher.js
+++ b/cipher.js
@@ -65,9 +65,13 @@ arr2.forEach(function(e) {
        arr.push(e);
        arr.shift();
        }
-
+       //A-M works!
+       else if (e > 64 && e < 91 && e + key < 65) {
+         arr.push(90 + (key + (e - 64)));
+         arr.shift();
+       }
      //a-m
-     else if (e + key < 97) {
+     else if (e > 96 && e < 123 && e + key < 97) {
        arr.push(122 + (key + (e - 96)));
        arr.shift();
      }
@@ -82,11 +86,7 @@ arr2.forEach(function(e) {
      arr.push(e + key);
      arr.shift();
    }
-   //A-M works!
-   else if (e + key < 65) {
-     arr.push(90 + (key + (e - 64)));
-     arr.shift();
-   }
+
    });
  }
 


### PR DESCRIPTION
**Negative shift on N-Z now working!**
- Moved A-M `if` statement up to just below if statement that checks for spaces.
- Added condition to `if` statements on A-M to check the number being passed by `e` to see if it's `> 64`, `< 91` and if the `e + key` will result in a number that `< 65`
- Added condition to `if` statement on N-Z to check the number being passed by `e` to see if it's `> 96`, `< 123` and if the `e + key` will result in a number that `< 97`

It looks like A-Z, a-z is working with positive and negative shifts and shifts that are greater than 26.
Testing required to confirm.